### PR TITLE
Run yii command in web process

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -46,6 +46,13 @@ class Module extends \yii\base\Module
     public $yiiScript = '@app/yii';
 
     /**
+     * @var string path to the yii console app configuration file
+     * used to run the yii command in the same process as the web application's
+     * if so chosen.
+     */
+    public $consoleConfig = '@app/config/console.php';
+    
+    /**
      * @var array the list of IPs that are allowed to access this module.
      * Each array element represents a single IP filter which can be either an IP address
      * or an address with wildcard (e.g. 192.168.0.*) to represent a network segment.

--- a/views/default/index.php
+++ b/views/default/index.php
@@ -18,17 +18,21 @@ jQuery(function($) {
     webshell.terminal(
         function(command, term) {
             if (command.indexOf('yii') === 0 || command.indexOf('yii') === 3) {
-                    $.jrpc('{$endpoint}', 'yii', [command.replace(/^yii ?/, '')], function(json) {
-                        term.echo(json.result);
+                    $.jrpc('{$endpoint}', 'yii', command.replace(/^yii ?/, ''), function(json) {
+                        term.echo(json.output);
                         scrollDown();
                     });
             } else if (command === 'help') {
                 term.echo('Available commands are:');
                 term.echo('');
-                term.echo("clear\tClear console");
-                term.echo('help\tThis help text');
-                term.echo('yii\tyii command');
-                term.echo('quit\tQuit web shell');
+                term.echo('help\t This help text');
+                term.echo('clear\tClear console');
+                term.echo('quit\t Quit web shell');
+                term.echo('yii [-wp|--runInWebProcess] <command>');
+                term.echo('\tcommand \t\t\t\t A yii console command. Type "yii help" to list available commands.');
+                term.echo('\t-wp|--runInWebProcess\tRun command in the web application process.');
+                term.echo('\t\t\t\t\t\t\t Does not require creating a background process via "popen",');
+                term.echo('\t\t\t\t\t\t\t a function which might be disabled in your PHP config.');
                 scrollDown();
             } else if (command === 'quit') {
                 var exitUrl = '{$quitUrl}';


### PR DESCRIPTION
`yii [-wp|--runInWebProcess] <command>` avoids popen and instead runs the command in the web app's process
